### PR TITLE
Migrate to use v1 API

### DIFF
--- a/lib/fluent/plugin/in_osquery.rb
+++ b/lib/fluent/plugin/in_osquery.rb
@@ -1,8 +1,13 @@
 # coding: utf-8
-require 'fluent/input'
-module Fluent
-  class OsqueryInput < Fluent::Input
+require 'json'
+require 'fluent/plugin/input'
+
+module Fluent::Plugin
+  class OsqueryInput < Fluent::Plugin::Input
     Fluent::Plugin.register_input('osquery', self)
+
+    helpers :timer
+
     config_param :tag, :string, default: 'osquery'
     config_param :interval, :integer, default: 60
     config_param :query, :string, default: 'select * from processes'
@@ -13,7 +18,6 @@ module Fluent
 
     def initialize
       super
-      require 'json'
     end
 
     def configure(conf)
@@ -21,55 +25,29 @@ module Fluent
     end
 
     def start
-      @loop = Coolio::Loop.new
-      @tw = TimerWatcher.new(interval, true, log, &method(:execute))
-      @tw.attach(@loop)
-      @thread = Thread.new(&method(:run))
+      super
+      timer_execute(:in_osquery_timer, interval, &method(:execute))
     end
 
     def shutdown
-      @tw.detach
-      @loop.stop
-      @thread.join
-    end
-
-    def run
-      @loop.run
-    rescue => e
-      @log.error 'unexpected error', error: e.to_s
-      @log.error_backtrace
+      super
     end
 
     private
 
     def execute
-      @time = Engine.now
+      @time = Fluent::Engine.now
       cmd = "osqueryi --json \"#{@query}\""
-      @log.debug(cmd)
+      log.debug(cmd)
       record = `#{cmd}`
       jsonrec = JSON.parse(record)
       jsonrec.each do |line|
-        @log.debug(line)
+        log.debug(line)
         router.emit(@tag, @time, line)
       end
     rescue => e
-      @log.error('faild to run', error: e.to_s, error_class: e.class.to_s)
-      @log.error_backtrace
-    end
-
-    class TimerWatcher < Coolio::TimerWatcher
-      def initialize(interval, repeat, log, &callback)
-        @log = log
-        @callback = callback
-        super(interval, repeat)
-      end
-
-      def on_timer
-        @callback.call
-      rescue => e
-        @log.error e.to_s
-        @log.error_backtrace
-      end
+      log.error('faild to run', error: e.to_s, error_class: e.class.to_s)
+      log.error_backtrace
     end
   end
 end

--- a/spec/fluent/plugin/in_osquery_spec.rb
+++ b/spec/fluent/plugin/in_osquery_spec.rb
@@ -8,14 +8,14 @@ CONFIG = BASE_CONFIG + %(
   interval 1
 )
 
-describe Fluent::OsqueryInput do
+describe Fluent::Plugin::OsqueryInput do
   before do
     Fluent::Test.setup
   end
 
   describe '#configure' do
     let(:d) do
-      Fluent::Test::InputTestDriver.new(Fluent::OsqueryInput)
+      Fluent::Test::Driver::Input.new(Fluent::Plugin::OsqueryInput)
     end
 
     context 'test of test' do
@@ -29,7 +29,7 @@ describe Fluent::OsqueryInput do
 
   describe '#run' do
     let(:d) do
-      Fluent::Test::InputTestDriver.new(Fluent::OsqueryInput)
+      Fluent::Test::Driver::Input.new(Fluent::Plugin::OsqueryInput)
         .configure(config)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_osquery'


### PR DESCRIPTION
To simplify plugin implementation, we can use timer plugin helper to
reduce raw cool.io timer pattern.